### PR TITLE
Drop rails inflection to avoid main app name conflicts

### DIFF
--- a/app/controllers/graphql/voyager/rails/explorers_controller.rb
+++ b/app/controllers/graphql/voyager/rails/explorers_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GraphQL
+module Graphql
   module Voyager
     module Rails
       class ExplorersController < ActionController::Base
@@ -10,7 +10,7 @@ module GraphQL
         end
 
         def graphql_endpoint_path
-          params[:graphql_path] || raise(%|You must include `graphql_path: "/my/endpoint"` when mounting GraphQL::Voyager::Rails::Engine|)
+          params[:graphql_path] || raise(%|You must include `graphql_path: "/my/endpoint"` when mounting Graphql::Voyager::Rails::Engine|)
         end
       end
     end

--- a/app/views/graphql/voyager/rails/explorers/show.html.erb
+++ b/app/views/graphql/voyager/rails/explorers/show.html.erb
@@ -11,7 +11,7 @@
       function introspectionProvider(introspectionQuery) {
         return fetch('<%= graphql_endpoint_path %>', {
           method: 'post',
-          headers: <%= GraphQL::Voyager::Rails.config.resolve_headers(self).to_json.html_safe %>,
+          headers: <%= Graphql::Voyager::Rails.config.resolve_headers(self).to_json.html_safe %>,
           body: JSON.stringify({query: introspectionQuery}),
           credentials: 'include',
         }).then(function (response) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-GraphQL::Voyager::Rails::Engine.routes.draw do
+Graphql::Voyager::Rails::Engine.routes.draw do
   get "/" => "explorers#show"
 end

--- a/graphql-voyager-rails.gemspec
+++ b/graphql-voyager-rails.gemspec
@@ -6,7 +6,7 @@ require "graphql/voyager/rails/version"
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
   spec.name        = "graphql-voyager-rails"
-  spec.version     = GraphQL::Voyager::Rails::VERSION
+  spec.version     = Graphql::Voyager::Rails::VERSION
   spec.authors     = ["Thomas McGoey-Smith"]
   spec.email       = ["hey@thomas.codes"]
   spec.homepage    = "https://github.com/tamcgoey/graphql-voyager-rails"

--- a/lib/graphql/voyager/rails.rb
+++ b/lib/graphql/voyager/rails.rb
@@ -2,21 +2,10 @@
 
 require "rails"
 
-if ActiveSupport::Inflector.method(:inflections).arity == 0
-  # Rails 3 does not take a language in inflections.
-  ActiveSupport::Inflector.inflections do |inflect|
-    inflect.acronym("GraphQL")
-  end
-else
-  ActiveSupport::Inflector.inflections(:en) do |inflect|
-    inflect.acronym("GraphQL")
-  end
-end
-
 require "graphql/voyager/rails/engine"
 require "graphql/voyager/rails/config"
 
-module GraphQL
+module Graphql
   module Voyager
     module Rails
       class << self

--- a/lib/graphql/voyager/rails/config.rb
+++ b/lib/graphql/voyager/rails/config.rb
@@ -3,7 +3,7 @@
 # Originally based on GrapiQL Rails Config
 # https://github.com/rmosolgo/graphiql-rails/blob/5770e774f9da754aa8c1eee5651d6c663ca8e2a2/lib/graphiql/rails/config.rb
 
-module GraphQL
+module Graphql
   module Voyager
     module Rails
       class Config

--- a/lib/graphql/voyager/rails/engine.rb
+++ b/lib/graphql/voyager/rails/engine.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-module GraphQL
+module Graphql
   module Voyager
     module Rails
       class Engine < ::Rails::Engine
-        isolate_namespace GraphQL::Voyager::Rails
+        isolate_namespace Graphql::Voyager::Rails
       end
     end
   end

--- a/lib/graphql/voyager/rails/version.rb
+++ b/lib/graphql/voyager/rails/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GraphQL
+module Graphql
   module Voyager
     module Rails
       VERSION = '1.0.2'

--- a/test/controllers/graphql/voyager/rails/explorers_controller_test.rb
+++ b/test/controllers/graphql/voyager/rails/explorers_controller_test.rb
@@ -2,16 +2,16 @@
 
 require 'test_helper'
 
-module GraphQL
+module Graphql
   module Voyager
     module Rails
       class ExplorersControllerTest < ActionController::TestCase
         setup do
-          @routes = GraphQL::Voyager::Rails::Engine.routes
+          @routes = Graphql::Voyager::Rails::Engine.routes
         end
 
         teardown do
-          GraphQL::Voyager::Rails.config.headers = {}
+          Graphql::Voyager::Rails.config.headers = {}
         end
 
         def graphql_params
@@ -26,7 +26,7 @@ module GraphQL
         end
 
         test 'it renders headers' do
-          GraphQL::Voyager::Rails.config.headers['Nonsense-Header'] = ->(_view_ctx) { 'Value' }
+          Graphql::Voyager::Rails.config.headers['Nonsense-Header'] = ->(_view_ctx) { 'Value' }
           get :show, graphql_params
           assert_includes(@response.body, %(\"Nonsense-Header\":\"Value\"))
           assert_includes(@response.body, %(\"X-CSRF-Token\"))

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  mount GraphQL::Voyager::Rails::Engine => "/graphql-voyager-rails"
+  mount Graphql::Voyager::Rails::Engine => "/graphql-voyager-rails"
 end

--- a/test/graphql/voyager/config_test.rb
+++ b/test/graphql/voyager/config_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-module GraphQL
+module Graphql
   module Voyager
     module Rails
       class ConfigTest < ActiveSupport::TestCase
@@ -13,7 +13,7 @@ module GraphQL
         end
 
         setup do
-          @config = GraphQL::Voyager::Rails::Config.new
+          @config = Graphql::Voyager::Rails::Config.new
           @view_context = MockViewContext.new
         end
 

--- a/test/graphql/voyager/engine_test.rb
+++ b/test/graphql/voyager/engine_test.rb
@@ -2,12 +2,12 @@
 
 require "test_helper"
 
-module GraphQL
+module Graphql
   module Voyager
     module Rails
       class EngineTest < ActiveSupport::TestCase
         test "it is defined" do
-          assert GraphQL::Voyager::Rails::Engine
+          assert Graphql::Voyager::Rails::Engine
         end
       end
     end

--- a/test/graphql/voyager/rails_test.rb
+++ b/test/graphql/voyager/rails_test.rb
@@ -2,12 +2,12 @@
 
 require 'test_helper'
 
-module GraphQL
+module Graphql
   module Voyager
     module Rails
       class Test < ActiveSupport::TestCase
         test "truth" do
-          assert_kind_of Module, GraphQL::Voyager::Rails
+          assert_kind_of Module, Graphql::Voyager::Rails
         end
       end
     end


### PR DESCRIPTION
Closes #10 

Dropping rails ActiveSupport inflection so we don't run into problems with conflicting `Graphql` classes in the core app.