### PR TITLE
Fix CSS Typo (again)

### DIFF
--- a/app/assets/stylesheets/graphql/voyager/rails/voyager-1.0.0-rc.28.css
+++ b/app/assets/stylesheets/graphql/voyager/rails/voyager-1.0.0-rc.28.css
@@ -356,7 +356,7 @@
 }
 
 .doc-category > .item > .description-box {
-  .margin-top: 5px;
+  margin-top: 5px;
 }
 
 .doc-category > .title {

--- a/lib/graphql/voyager/rails/version.rb
+++ b/lib/graphql/voyager/rails/version.rb
@@ -3,7 +3,7 @@
 module Graphql
   module Voyager
     module Rails
-      VERSION = '1.0.3'
+      VERSION = '1.0.4'
     end
   end
 end


### PR DESCRIPTION
CSS still has an extra `.` 😄https://github.com/sourdoughdev/graphql-voyager-rails/pull/9/files

https://github.com/APIs-guru/graphql-voyager/pull/119/files fixes this for real, but it hasn't been included in a release yet.